### PR TITLE
Panic instead of os.Exit(1) on missing interaction

### DIFF
--- a/recorder/recorder.go
+++ b/recorder/recorder.go
@@ -27,7 +27,6 @@ package recorder
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -136,7 +135,7 @@ func New(cassetteName string) (*Recorder, error) {
 		interaction, err := requestHandler(r, c, mode)
 
 		if err != nil {
-			log.Fatalf("Failed to process request for URL %s: %s", r.URL, err)
+			panic(fmt.Errorf("Failed to process request for URL %s: %s", r.URL, err))
 		}
 
 		w.WriteHeader(interaction.Response.Code)


### PR DESCRIPTION
Shortcomings of the log.Fatal approach:

1. Aborts the execution of other test funcs when the current test func hits this condition.
2. Process exits before teardown has a chance to complete (like via TestMain).  

Panic is appropriate here I think.  Another approach would be to let whoever created the recorder to set an error callback, but I don't see how that differs materially from simply panicking.

Thanks for this fantastically effective library!