### PR TITLE
Support https

### DIFF
--- a/recorder/recorder.go
+++ b/recorder/recorder.go
@@ -30,9 +30,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/http/httptest"
 	"net/http/httputil"
-	"net/url"
 	"os"
 
 	"github.com/dnaeon/go-vcr/cassette"
@@ -50,14 +48,11 @@ type Recorder struct {
 	// Operating mode of the recorder
 	mode int
 
-	// HTTP server used to mock requests
-	server *httptest.Server
-
 	// Cassette used by the recorder
 	cassette *cassette.Cassette
 
 	// Transport that can be used by clients to inject
-	Transport *http.Transport
+	Transport *Transport
 }
 
 // Proxies client requests to their original destination
@@ -153,38 +148,11 @@ func New(cassetteName string) (*Recorder, error) {
 		mode = ModeReplaying
 	}
 
-	// Handler for client requests
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Pass cassette and mode to handler, so that interactions can be
-		// retrieved or recorded depending on the current recorder mode
-		interaction, err := requestHandler(r, c, mode)
-
-		if err != nil {
-			panic(fmt.Errorf("Failed to process request for URL %s: %s", r.URL, err))
-		}
-
-		w.WriteHeader(interaction.Response.Code)
-		fmt.Fprintln(w, interaction.Response.Body)
-	})
-
-	// HTTP server used to mock requests
-	server := httptest.NewServer(handler)
-
-	// A proxy function which routes all requests through our HTTP server
-	// Can be used by clients to inject into their own transports
-	proxyURL, err := url.Parse(server.URL)
-	if err != nil {
-		return nil, err
-	}
-
 	// A transport which can be used by clients to inject
-	transport := &http.Transport{
-		Proxy: http.ProxyURL(proxyURL),
-	}
+	transport := &Transport{c: c, mode: mode}
 
 	r := &Recorder{
 		mode:      mode,
-		server:    server,
 		cassette:  c,
 		Transport: transport,
 	}
@@ -194,8 +162,6 @@ func New(cassetteName string) (*Recorder, error) {
 
 // Stop is used to stop the recorder and save any recorded interactions
 func (r *Recorder) Stop() error {
-	r.server.Close()
-
 	if r.mode == ModeRecording {
 		if err := r.cassette.Save(); err != nil {
 			return err
@@ -203,4 +169,41 @@ func (r *Recorder) Stop() error {
 	}
 
 	return nil
+}
+
+// Transport either records or replays responses from a cassette, depending on its mode
+type Transport struct {
+	c    *cassette.Cassette
+	mode int
+}
+
+// RoundTrip implements the http.RoundTripper interface
+func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
+	// Pass cassette and mode to handler, so that interactions can be
+	// retrieved or recorded depending on the current recorder mode
+	interaction, err := requestHandler(r, t.c, t.mode)
+
+	if err != nil {
+		panic(fmt.Errorf("Failed to process request for URL %s: %s", r.URL, err))
+	}
+
+	buf := bytes.NewBuffer([]byte(interaction.Response.Body))
+
+	return &http.Response{
+		Status:        interaction.Response.Status,
+		StatusCode:    interaction.Response.Code,
+		Proto:         "HTTP/1.0",
+		ProtoMajor:    1,
+		ProtoMinor:    0,
+		Request:       r,
+		Header:        interaction.Response.Headers,
+		Close:         true,
+		ContentLength: int64(buf.Len()),
+		Body:          ioutil.NopCloser(buf),
+	}, nil
+}
+
+// CancelRequest implements the github.com/coreos/etcd/client.CancelableTransport interface
+func (t *Transport) CancelRequest(req *http.Request) {
+	// noop
 }

--- a/recorder/recorder.go
+++ b/recorder/recorder.go
@@ -86,8 +86,7 @@ func requestHandler(r *http.Request, c *cassette.Cassette, mode int) (*cassette.
 
 	// Perform client request to it's original
 	// destination and record interactions
-	body := ioutil.NopCloser(r.Body)
-	req, err := http.NewRequest(r.Method, r.URL.String(), body)
+	req, err := http.NewRequest(r.Method, r.URL.String(), r.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -98,10 +97,13 @@ func requestHandler(r *http.Request, c *cassette.Cassette, mode int) (*cassette.
 		return nil, err
 	}
 
-	// Record the interaction and add it to the cassette
-	reqBody, err := ioutil.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
+	var reqBody []byte
+	if req.Body != nil {
+		// Record the interaction and add it to the cassette
+		reqBody, err = ioutil.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	respBody, err := ioutil.ReadAll(resp.Body)

--- a/recorder/recorder_test.go
+++ b/recorder/recorder_test.go
@@ -126,16 +126,14 @@ func TestRecord(t *testing.T) {
 	}
 
 	// Re-run without the actual server
-	func() {
-		r, err := recorder.New(cassPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer r.Stop()
+	r, err := recorder.New(cassPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Stop()
 
-		t.Log("replaying")
-		for _, test := range tests {
-			test.perform(t, serverURL, r)
-		}
-	}()
+	t.Log("replaying")
+	for _, test := range tests {
+		test.perform(t, serverURL, r)
+	}
 }

--- a/recorder/recorder_test.go
+++ b/recorder/recorder_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2015 Marin Atanasov Nikolov <dnaeon@gmail.com>
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer
+//    in this position and unchanged.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+// IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package recorder_test
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dnaeon/go-vcr/recorder"
+)
+
+type recordTest struct {
+	method string
+	body   io.Reader
+	out    string
+}
+
+func (test recordTest) perform(t *testing.T, url string, r *recorder.Recorder) {
+	// Create an HTTP client and inject our transport
+	client := &http.Client{
+		Transport: r.Transport, // Inject our transport!
+	}
+
+	req, err := http.NewRequest(test.method, url, test.body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	content, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(content)) != test.out {
+		t.Fatalf("got:\t%s\n\twant:\t%s", string(content), string(test.out))
+	}
+}
+
+func TestRecord(t *testing.T) {
+	runID := time.Now().Format(time.RFC3339Nano)
+	tests := []recordTest{
+		{
+			method: "GET",
+			out:    "GET " + runID,
+		},
+		{
+			method: "POST",
+			body:   strings.NewReader("post body"),
+			out:    "POST " + runID + "\npost body",
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cassPath := path.Join(dir, "record_test")
+	var serverURL string
+
+	func() {
+		// Start our recorder
+		r, err := recorder.New(cassPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Stop() // Make sure recorder is stopped once done with it
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "%s %s", r.Method, runID)
+			if r.Body != nil {
+				defer r.Body.Close()
+				fmt.Fprintln(w)
+				io.Copy(w, r.Body)
+			}
+		}))
+		defer server.Close()
+		serverURL = server.URL
+
+		for _, test := range tests {
+			test.perform(t, serverURL, r)
+		}
+	}()
+
+	// Re-run without the actual server
+	func() {
+		r, err := recorder.New(cassPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Stop()
+
+		for _, test := range tests {
+			test.perform(t, serverURL, r)
+		}
+	}()
+}


### PR DESCRIPTION
Let's try this again!

The issue was wrapping ioutil.NopCloser(r.Body) when r.Body is nil.  The result is not nil but panics when anyone tries to read from it.  http.NewRequest wraps the Reader in a ioutil.NopCloser call for us anyway, if it's not already an io.ReadCloser and it's not nil.  
