### PR TITLE
Add custom interaction matching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,29 @@ func main() {
 }
 ```
 
+## Custom Request Matching
+During replay mode, You can customize the way incoming requests are
+matched against the recorded request/response pairs by defining a
+Matcher function. For example, the following matcher will match on
+method, URL and body:
+
+```
+r, err := recorder.New("fixtures/etcd")
+if err != nil {
+	log.Fatal(err)
+}
+defer r.Stop() // Make sure recorder is stopped once done with it
+
+r.SetMatcher(func(r *http.Request, i cassette.Request) bool {
+    var b bytes.Buffer
+	if _, err := b.ReadFrom(r.Body); err != nil {
+		return false
+	}
+	r.Body = ioutil.NopCloser(&b)
+	return cassette.DefaultMatcher(r, i) && (b.String() == "" || b.String() == i.Body)
+})
+```
+
 ## License
 
 `go-vcr` is Open Source and licensed under the

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Matcher function. For example, the following matcher will match on
 method, URL and body:
 
 ```
-r, err := recorder.New("fixtures/etcd")
+r, err := recorder.New("fixtures/matchers")
 if err != nil {
 	log.Fatal(err)
 }

--- a/recorder/recorder.go
+++ b/recorder/recorder.go
@@ -35,7 +35,7 @@ import (
 	"net/http/httputil"
 	"os"
 
-	"github.com/bigcommerce-labs/go-vcr/cassette"
+	"github.com/dnaeon/go-vcr/cassette"
 )
 
 // Recorder states

--- a/recorder/recorder.go
+++ b/recorder/recorder.go
@@ -35,7 +35,7 @@ import (
 	"net/http/httputil"
 	"os"
 
-	"github.com/dnaeon/go-vcr/cassette"
+	"github.com/bigcommerce-labs/go-vcr/cassette"
 )
 
 // Recorder states
@@ -207,4 +207,9 @@ func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 // CancelRequest implements the github.com/coreos/etcd/client.CancelableTransport interface
 func (t *Transport) CancelRequest(req *http.Request) {
 	// noop
+}
+
+// SetMatcher sets a function to match requests against recorded HTTP interactions.
+func (r *Recorder) SetMatcher(matcher cassette.Matcher) {
+	r.cassette.Matcher = matcher
 }

--- a/recorder/recorder_test.go
+++ b/recorder/recorder_test.go
@@ -37,8 +37,8 @@ import (
 	"time"
 
 	"bytes"
-	"github.com/bigcommerce-labs/go-vcr/cassette"
-	"github.com/bigcommerce-labs/go-vcr/recorder"
+	"github.com/dnaeon/go-vcr/cassette"
+	"github.com/dnaeon/go-vcr/recorder"
 )
 
 type recordTest struct {


### PR DESCRIPTION
Interactions (recorded request/response pairs) were only matched
according to request method and URL during replay. This limits
the usefulness of go-vcr for testing HTTP requests because the
interesting state is often in the headers or body. For example, a
idiomatic PUT action in a REST API may have the same URL but respond
differently based on the body.

This PR matches requests to interactions using a Matcher function.
Users of the go-vcr library can define and use custom matchers in
their tests by setting the matcher on the recorder with SetMatcher.