### PR TITLE
Implement http.RoundTripper on recorder.Recorder directly CLOSES dnaeon/go-vcr#9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ go:
   - 1.7
   - tip
 
+go_import_path: github.com/dnaeon/go-vcr
+
 install:
   - make get
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ func main() {
 	cfg := client.Config{
 		Endpoints:               []string{"http://127.0.0.1:2379"},
 		HeaderTimeoutPerRequest: time.Second,
-		Transport:               r.Transport, // Inject our transport!
+		Transport:               r, // Inject as transport!
 	}
 
 	// Create an etcd client using the above configuration

--- a/example/etcd_test.go
+++ b/example/etcd_test.go
@@ -46,7 +46,7 @@ func TestEtcd(t *testing.T) {
 	cfg := client.Config{
 		Endpoints:               []string{"http://127.0.0.1:2379"},
 		HeaderTimeoutPerRequest: time.Second,
-		Transport:               r.Transport, // Inject our transport!
+		Transport:               r, // Inject as transport!
 	}
 
 	// Create an etcd client using the above configuration

--- a/example/https_test.go
+++ b/example/https_test.go
@@ -43,7 +43,7 @@ func TestHTTPS(t *testing.T) {
 
 	// Create an HTTP client and inject our transport
 	client := &http.Client{
-		Transport: r.Transport, // Inject our transport!
+		Transport: r, // Inject as transport!
 	}
 
 	url := "https://www.iana.org/domains/reserved"

--- a/example/simple_test.go
+++ b/example/simple_test.go
@@ -43,7 +43,7 @@ func TestSimple(t *testing.T) {
 
 	// Create an HTTP client and inject our transport
 	client := &http.Client{
-		Transport: r.Transport, // Inject our transport!
+		Transport: r, // Inject as transport!
 	}
 
 	url := "http://golang.org/"

--- a/recorder/recorder_test.go
+++ b/recorder/recorder_test.go
@@ -50,7 +50,7 @@ type recordTest struct {
 func (test recordTest) perform(t *testing.T, url string, r *recorder.Recorder) {
 	// Create an HTTP client and inject our transport
 	client := &http.Client{
-		Transport: r.Transport, // Inject our transport!
+		Transport: r, // Inject as transport!
 	}
 
 	req, err := http.NewRequest(test.method, url, strings.NewReader(test.body))


### PR DESCRIPTION
CLOSES dnaeon/go-vcr#9

- Simplifies `Recorder` to directly implement `http.RoundTripper` and not need to pass around cassette and mode to a `Transport`