### PR TITLE
Avoid recursive CancelRequest. Fixes #23

### DIFF
--- a/recorder/recorder.go
+++ b/recorder/recorder.go
@@ -217,7 +217,12 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // CancelRequest implements the github.com/coreos/etcd/client.CancelableTransport interface
 func (r *Recorder) CancelRequest(req *http.Request) {
-	r.CancelRequest(req)
+	type cancelableTransport interface {
+		CancelRequest(req *http.Request)
+	}
+	if ct, ok := r.realTransport.(cancelableTransport); ok {
+		ct.CancelRequest(req)
+	}
 }
 
 // SetMatcher sets a function to match requests against recorded HTTP interactions.


### PR DESCRIPTION
This code was posted originally on issue #23, but was not put on the project by anyone, so i'm sending it as a PR here.

Because i'm testing go-vcr on a personal project, I need to have this method working, because for some reason when using go-vcr with a `http.Client` this method is called and causes the problem described on #23.

Thanks.