### PR TITLE
support response duration

### DIFF
--- a/cassette/cassette.go
+++ b/cassette/cassette.go
@@ -81,6 +81,9 @@ type Response struct {
 
 	// Response status code
 	Code int `yaml:"code"`
+
+	// Response duration (something like "100ms" or "10s")
+	Duration string `yaml:"duration"`
 }
 
 // Interaction type contains a pair of request/response for a
@@ -95,7 +98,7 @@ type Interaction struct {
 // own criteria.
 type Matcher func(*http.Request, Request) bool
 
-// Default Matcher is used when a custom matcher is not defined
+// DefaultMatcher is used when a custom matcher is not defined
 // and compares only the method and URL.
 func DefaultMatcher(r *http.Request, i Request) bool {
 	return r.Method == i.Method && r.URL.String() == i.URL

--- a/example/fixtures/golang-org.yaml
+++ b/example/fixtures/golang-org.yaml
@@ -118,3 +118,4 @@ interactions:
       - Google Frontend
     status: 200 OK
     code: 200
+    duration: 2s

--- a/example/simple_test.go
+++ b/example/simple_test.go
@@ -29,6 +29,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dnaeon/go-vcr/recorder"
 )
@@ -47,9 +48,15 @@ func TestSimple(t *testing.T) {
 	}
 
 	url := "http://golang.org/"
+	// measure the duration, expecting ~2s
+	start := time.Now()
 	resp, err := client.Get(url)
 	if err != nil {
 		t.Fatalf("Failed to get url %s: %s", url, err)
+	}
+	end := time.Now()
+	if end.UnixNano()-start.UnixNano() < 2e9 { // should be 2s, so will be definitely wrong if under
+		t.Fatalf("unexpected duration: %vns", (end.UnixNano() - start.UnixNano()))
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/recorder/recorder.go
+++ b/recorder/recorder.go
@@ -34,6 +34,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
+	"time"
 
 	"github.com/dnaeon/go-vcr/cassette"
 )
@@ -199,6 +200,15 @@ func (r *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, req.Context().Err()
 	default:
 		buf := bytes.NewBuffer([]byte(interaction.Response.Body))
+		// apply the duration defined in the interaction
+		if interaction.Response.Duration != "" {
+			d, err := time.ParseDuration(interaction.Duration)
+			if err != nil {
+				return nil, err
+			}
+			// block for the configured 'duration' to simulate the network latency and server processing time.
+			<-time.After(d)
+		}
 
 		return &http.Response{
 			Status:        interaction.Response.Status,

--- a/recorder/recorder_test.go
+++ b/recorder/recorder_test.go
@@ -149,7 +149,7 @@ func TestModePlaybackMissing(t *testing.T) {
 	for _, test := range tests {
 		resp, err := test.performReq(t, context.Background(), serverURL, recorder)
 		if resp != nil {
-			t.Fatalf("Expected response to be nil but was %s", resp)
+			t.Fatalf("Expected response to be nil but was %v", resp)
 		}
 
 		urlErr, ok := err.(*url.Error)


### PR DESCRIPTION
duration can be configured as a string that can be
parsed by `time.ParseDuration()` (eg: '10ms`) to
simulate the total network latency/tranfert and
server processing time of the request.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>