### PR TITLE
Add filters to `Recorder` to allow redacting sensitive data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,30 @@ r.SetMatcher(func(r *http.Request, i cassette.Request) bool {
 })
 ```
 
+## Protecting Sensitive Data
+
+You often provide sensitive data, such as API credentials, when making
+requests against a service.
+By default, this data will be stored in the recorded data but you probably
+don't want this.
+Removing or replacing data before it is stored can be done by adding one or
+more `Filter`s to your `Recorder`.
+Here is an example that removes the `Authorization` header from all requests:
+
+```go
+r, err := recorder.New("fixtures/filters")
+if err != nil {
+	log.Fatal(err)
+}
+defer r.Stop() // Make sure recorder is stopped once done with it
+
+// Add a filter which removes Authorization headers from all requests:
+recorder.AddFilter(func(i *cassette.Interaction) error {
+    delete(i.Request.Header, "Authorization")
+    return nil
+})
+```
+
 ## License
 
 `go-vcr` is Open Source and licensed under the

--- a/cassette/cassette.go
+++ b/cassette/cassette.go
@@ -107,10 +107,6 @@ func DefaultMatcher(r *http.Request, i Request) bool {
 // Filter function allows modification of an interaction before saving.
 type Filter func(*Interaction) error
 
-func DefaultFilter(*Interaction) error {
-	return nil
-}
-
 // Cassette type
 type Cassette struct {
 	// Name of the cassette
@@ -132,7 +128,7 @@ type Cassette struct {
 	Matcher Matcher `yaml:"-"`
 
 	// Filters interactions before being saved.
-	Filter Filter `yaml:"-"`
+	Filters []Filter `yaml:"-"`
 }
 
 // New creates a new empty cassette
@@ -143,7 +139,7 @@ func New(name string) *Cassette {
 		Version:      cassetteFormatV1,
 		Interactions: make([]*Interaction, 0),
 		Matcher:      DefaultMatcher,
-		Filter:       DefaultFilter,
+		Filters:       make([]Filter, 0),
 	}
 
 	return c

--- a/cassette/cassette.go
+++ b/cassette/cassette.go
@@ -104,6 +104,13 @@ func DefaultMatcher(r *http.Request, i Request) bool {
 	return r.Method == i.Method && r.URL.String() == i.URL
 }
 
+// Filter function allows modification of an interaction before saving.
+type Filter func(*Interaction) error
+
+func DefaultFilter(*Interaction) error {
+	return nil
+}
+
 // Cassette type
 type Cassette struct {
 	// Name of the cassette
@@ -123,6 +130,9 @@ type Cassette struct {
 
 	// Matches actual request with interaction requests.
 	Matcher Matcher `yaml:"-"`
+
+	// Filters interactions before being saved.
+	Filter Filter `yaml:"-"`
 }
 
 // New creates a new empty cassette
@@ -133,6 +143,7 @@ func New(name string) *Cassette {
 		Version:      cassetteFormatV1,
 		Interactions: make([]*Interaction, 0),
 		Matcher:      DefaultMatcher,
+		Filter:       DefaultFilter,
 	}
 
 	return c

--- a/recorder/recorder.go
+++ b/recorder/recorder.go
@@ -130,9 +130,11 @@ func requestHandler(r *http.Request, c *cassette.Cassette, mode Mode, realTransp
 			Code:    resp.StatusCode,
 		},
 	}
-	err = c.Filter(interaction)
-	if err != nil {
-		return nil, err
+	for _, filter := range c.Filters {
+		err = filter(interaction)
+		if err != nil {
+			return nil, err
+		}
 	}
 	c.AddInteraction(interaction)
 
@@ -263,9 +265,11 @@ func (r *Recorder) SetMatcher(matcher cassette.Matcher) {
 	}
 }
 
-// SetFilter is a hook to modify a request before it is recorded, for example to remove sensitive parameters.
-func (r *Recorder) SetFilter(filter cassette.Filter) {
+// AddFilter appends a hook to modify a request before it is recorded.
+//
+// Filters are useful for filtering out sensitive parameters from the recorded data.
+func (r *Recorder) AddFilter(filter cassette.Filter) {
 	if r.cassette != nil {
-		r.cassette.Filter = filter
+		r.cassette.Filters = append(r.cassette.Filters, filter)
 	}
 }

--- a/recorder/recorder.go
+++ b/recorder/recorder.go
@@ -37,7 +37,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/dnaeon/go-vcr/cassette"
+	"github.com/judy2k/go-vcr/cassette"
 )
 
 // Mode represents recording/playback mode
@@ -107,6 +107,7 @@ func requestHandler(r *http.Request, c *cassette.Cassette, mode Mode, realTransp
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	respBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -128,6 +129,10 @@ func requestHandler(r *http.Request, c *cassette.Cassette, mode Mode, realTransp
 			Status:  resp.Status,
 			Code:    resp.StatusCode,
 		},
+	}
+	err = c.Filter(interaction)
+	if err != nil {
+		return nil, err
 	}
 	c.AddInteraction(interaction)
 
@@ -255,5 +260,12 @@ func (r *Recorder) CancelRequest(req *http.Request) {
 func (r *Recorder) SetMatcher(matcher cassette.Matcher) {
 	if r.cassette != nil {
 		r.cassette.Matcher = matcher
+	}
+}
+
+// SetFilter is a hook to modify a request before it is recorded, for example to remove sensitive parameters.
+func (r *Recorder) SetFilter(filter cassette.Filter) {
+	if r.cassette != nil {
+		r.cassette.Filter = filter
 	}
 }

--- a/recorder/recorder.go
+++ b/recorder/recorder.go
@@ -37,7 +37,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/judy2k/go-vcr/cassette"
+	"github.com/dnaeon/go-vcr/cassette"
 )
 
 // Mode represents recording/playback mode

--- a/recorder/recorder_test.go
+++ b/recorder/recorder_test.go
@@ -183,6 +183,47 @@ func TestModeDisabled(t *testing.T) {
 	}
 }
 
+func TestFilter(t *testing.T) {
+	dummyBody := "[REDACTED]"
+
+	runID, cassPath, tests := setupTests(t, "test_filter")
+	recorder, server := httpRecorderTestSetup(t, runID, cassPath, recorder.ModeRecording)
+	serverURL := server.URL
+
+	// Add a filter which replaces each request body in the stored cassette:
+	recorder.AddFilter(func(i *cassette.Interaction) error {
+		i.Request.Body = dummyBody
+		return nil
+	})
+
+	t.Log("make http requests")
+	for _, test := range tests {
+		test.perform(t, serverURL, recorder)
+	}
+
+	// Make sure recorder is stopped once done with it
+	server.Close()
+	t.Log("server shut down")
+
+	recorder.Stop()
+	t.Log("recorder stopped")
+
+	// Load the cassette we just stored:
+	c, err := cassette.Load(cassPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert that each body has been set to our dummy value
+	for i := range tests {
+		body := c.Interactions[i].Request.Body
+		if body != dummyBody {
+			t.Fatalf("got:\t%s\n\twant:\t%s", string(body), string(dummyBody))
+		}
+	}
+
+}
+
 func httpRecorderTestSetup(t *testing.T, runID string, cassPath string, mode recorder.Mode) (*recorder.Recorder, *httptest.Server) {
 	// Start our recorder
 	recorder, err := recorder.NewAsMode(cassPath, mode, http.DefaultTransport)


### PR DESCRIPTION
This is probably best described by the addition to the README in this PR:

You often provide sensitive data, such as API credentials, when making requests against a service. By default, this data will be stored in the recorded data but you probably don't want this.
Removing or replacing data before it is stored can be done by adding one or more `Filter`s to your `Recorder`. Here is an example that removes the `Authorization` header from all requests:

```go
r, err := recorder.New("fixtures/filters")
if err != nil {
	log.Fatal(err)
}
defer r.Stop() // Make sure recorder is stopped once done with it

// Add a filter which removes Authorization headers from all requests:
recorder.AddFilter(func(i *cassette.Interaction) error {
    delete(i.Request.Header, "Authorization")
    return nil
})
```
