### PR TITLE
Add nil check in Custom Request Matching section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ if err != nil {
 defer r.Stop() // Make sure recorder is stopped once done with it
 
 r.SetMatcher(func(r *http.Request, i cassette.Request) bool {
+	if r.Body == nil {
+		return cassette.DefaultMatcher(r, i)
+	}
 	var b bytes.Buffer
 	if _, err := b.ReadFrom(r.Body); err != nil {
 		return false


### PR DESCRIPTION
Because some requests contain empty body, the example code should first
check if the body is `nil` before passed into `ReadFrom`.