### PR TITLE
feat: add `*Recorder.AddSaveFilter` to redact interactions before saving

### DIFF
--- a/recorder/recorder.go
+++ b/recorder/recorder.go
@@ -292,6 +292,16 @@ func (r *Recorder) AddFilter(filter cassette.Filter) {
 	}
 }
 
+// AddSaveFilter appends a hook to modify a request before it is saved.
+//
+// This filter is suitable for treating recorded responses to remove sensitive data. Altering responses using a regular
+// AddFilter can have unintended consequences on code that is consuming responses.
+func (r *Recorder) AddSaveFilter(filter cassette.Filter) {
+	if r.cassette != nil {
+		r.cassette.SaveFilters = append(r.cassette.SaveFilters, filter)
+	}
+}
+
 // Mode returns recorder state
 func (r *Recorder) Mode() Mode {
 	return r.mode


### PR DESCRIPTION
Closes #54 

Adds a new type of filter that is applied to interactions just before they are saved. These filters are added using `*Recorder.AddSaveFilter`.

## Why do we need this?

(the following explanation assumes VCR is in recording mode)

Imagine a work with an API that authenticates and authorizes requests using OAuth client credentials. The first step when interacting with this API is to acquire an access token and then make the intended API requests:

```
> POST /oauth/token
client_id=my_sample_app&client_secret=super-secret-credentials

< {"access_token": "390278941074fe1a1acd"}


> POST /blog/1234/comments
> Authorization: Bearer 390278941074fe1a1acd

{"message": "cool blog posts"}

< {"comment_id": "8043891dde"}
```

If we use an `AddFilter` to redact to scrub the access_token like so:

```go
rec.AddFilter(func(i *cassette.Interaction) error {
	i.Response.Body = `{"access_token": "[REDACTED]"}`
	return nil
})
```

Then the second request will be made like so:

```
> POST /blog/1234/comments
> Authorization: Bearer [REDACTED]

{"message": "cool blog posts"}

< {"comment_id": "8043891dde"}
```

This is because the response is mutated in the recorder's `RoundTripper` and the mutation is used to build the `http.Response` before being passed on to the caller.

So this means we cannot interfere with the response at the point where the current filters are added.

## Solution

To get around this problem, we allow VCR users to register another set of filters that are applied when interactions are being saved. At that point, it is safe to mutate recorded interactions.