### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
-
+arch:
+  - AMD64
+  - ppc64le
 go:
   - 1.15
   - 1.14
@@ -29,3 +31,11 @@ after_success:
 matrix:
   allow_failures:
     - go: tip
+    - go: 1.7
+      arch: ppc64le
+    - go: 1.8
+      arch: ppc64le
+    - go: 1.9
+      arch: ppc64le
+    - go: 1.10
+      arch: ppc64le


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.