### PR TITLE
Allow interactions to be replayed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ _testmain.go
 
 # Ignore test code coverage
 coverage.txt
+
+.idea/

--- a/cassette/cassette.go
+++ b/cassette/cassette.go
@@ -125,6 +125,8 @@ type Cassette struct {
 	Mu sync.RWMutex `yaml:"mu,omitempty"`
 	// Interactions between client and server
 	Interactions []*Interaction `yaml:"interactions"`
+	// ReplayableInteractions defines whether to allow interactions to be replayed or not
+	ReplayableInteractions bool `yaml:"-"`
 
 	// Matches actual request with interaction requests.
 	Matcher Matcher `yaml:"-"`
@@ -176,7 +178,7 @@ func (c *Cassette) GetInteraction(r *http.Request) (*Interaction, error) {
 	c.Mu.Lock()
 	defer c.Mu.Unlock()
 	for _, i := range c.Interactions {
-		if !i.replayed && c.Matcher(r, i.Request) {
+		if (c.ReplayableInteractions || !i.replayed) && c.Matcher(r, i.Request) {
 			i.replayed = true
 			return i, nil
 		}

--- a/recorder/recorder.go
+++ b/recorder/recorder.go
@@ -277,6 +277,13 @@ func (r *Recorder) SetMatcher(matcher cassette.Matcher) {
 	}
 }
 
+// SetReplayableInteractions defines whether to allow interactions to be replayed or not.
+func (r *Recorder) SetReplayableInteractions(replayable bool) {
+	if r.cassette != nil {
+		r.cassette.ReplayableInteractions = replayable
+	}
+}
+
 // AddPassthrough appends a hook to determine if a request should be ignored by the
 // recorder.
 func (r *Recorder) AddPassthrough(pass Passthrough) {


### PR DESCRIPTION
Hello there.
I'm trying to setup go-vcr as a mocker for external service calls in my local development environment, however, this is not possible at the moment since interactions are only playable once.
This PR adds an optional flag to allow for interactions to be replayed.