### PR TITLE
Save cassettes without any interactions

### DIFF
--- a/cassette/cassette.go
+++ b/cassette/cassette.go
@@ -293,11 +293,6 @@ func (c *Cassette) Save() error {
 	c.Mu.RLock()
 	defer c.Mu.RUnlock()
 
-	// Save cassette file only if there were any interactions made
-	if len(c.Interactions) == 0 {
-		return nil
-	}
-
 	// Create directory for cassette if missing
 	cassetteDir := filepath.Dir(c.File)
 	if _, err := os.Stat(cassetteDir); os.IsNotExist(err) {


### PR DESCRIPTION
This is often required when writing table-driven tests where some of the test cases don't produce any interactions (like when validation fails) but the setup and test code is the same for every test case. In this case, on a replay these tests then fail because the cassette for the test cannot be found.

Imagine this test code (I'll try to make it as succinct as possible):

```go
package example

import (
	"flag"
	"testing"

	"gopkg.in/dnaeon/go-vcr.v3/recorder"
)

var updateTestdata = flag.Bool("update", false, "update test data")

func TestSomething(t *testing.T) {
	type args struct {
		service string
	}
	tests := []struct {
		name string
	}{
		{
			name: "test 1",
		},
		{
			name: "test 2",
		},
	}
	for _, tt := range tests {
		t.Run(tt.name, func(t *testing.T) {
			cassetteName := t.Name()
			opts := &recorder.Options{
				CassetteName: cassetteName,
				Mode:         recorder.ModeReplayOnly,
			}
			if *updateTestdata {
				opts.Mode = recorder.ModeRecordOnly
			}

			recorder, err := recorder.NewWithOptions(opts)
			if err != nil {
				t.Fatalf("creating recorder: %v", err)
			}

			// test code

			if err := recorder.Stop(); err != nil {
				t.Fatalf("stopping recorder: %v", err)
			}
		})
	}
}
```

Imagine this were testing an HTTP API and some tests would fail validation and not do any calls to the API that's being tested, resulting in no interactions for that cassette.

I have a Makefile target that runs this using `go test -v ./... -updateTestdata` which sets the mode to `recorder.ModeRecordOnly`. In CI the mode is then set to `recorder.ModeReplayOnly`. Because the cassette isn't there with the current code, it'll fail on those tests. I also decided against using a single cassette for the whole test function because that's brittle and will prevent us from adding more test cases in the middle and will result in one big cassette that can't be grasped easily.

Dropping these three lines of code will write a file like this:
```yml
---
version: 2
interactions: []
```

…which is perfectly good. Removing this code also doesn't break any tests.

I know, of course, that this is a behavior change. I can also make it configurable but I decided against that for now.