### PR TITLE
[recorder] add option to load cassette from embed.Fs

### DIFF
--- a/examples/https_test.go
+++ b/examples/https_test.go
@@ -25,6 +25,7 @@
 package vcr_test
 
 import (
+	"embed"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -32,9 +33,16 @@ import (
 	"gopkg.in/dnaeon/go-vcr.v3/recorder"
 )
 
+//go:embed fixtures
+var f embed.FS
+
 func TestHTTPS(t *testing.T) {
 	// Start our recorder
-	r, err := recorder.New("fixtures/iana-reserved-domains")
+	r, err := recorder.NewWithOptions(&recorder.Options{
+		CassetteName: "fixtures/iana-reserved-domains",
+		Mode:         recorder.ModeRecordOnce,
+		Fs:           f,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/examples/json_test.go
+++ b/examples/json_test.go
@@ -44,7 +44,11 @@ type payload struct {
 }
 
 func TestJSON(t *testing.T) {
-	r, err := recorder.New("fixtures/json-content-type")
+	r, err := recorder.NewWithOptions(&recorder.Options{
+		CassetteName: "fixtures/json-content-type",
+		Mode:         recorder.ModeRecordOnce,
+		Fs:           f,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/examples/simple_test.go
+++ b/examples/simple_test.go
@@ -34,7 +34,11 @@ import (
 
 func TestSimple(t *testing.T) {
 	// Start our recorder
-	r, err := recorder.New("fixtures/golang-org")
+	r, err := recorder.NewWithOptions(&recorder.Options{
+		CassetteName: "fixtures/golang-org",
+		Mode:         recorder.ModeRecordOnce,
+		Fs:           f,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Describe your changes
I want a way to load fixtures from an embedded filesystem, so I can use the recorder for my integration tests but also to create fakes that I use while my process is running (development / sandbox mode / etc) 

This PR adds an option to create a recorder with an embedded filesystem, and if set optionally loads the cassette from it. 

I didn't spend much time making the code nice, it is a little messy for my taste but it does work.  If there is support for the idea Im happy to make any adjustments necessary to get the PR merged. 

## Checklist before requesting a review
tests pass