### PR TITLE
[cassette] pass cassette pointer to yaml unmarshal instead pointer-to…

### DIFF
--- a/cassette/cassette.go
+++ b/cassette/cassette.go
@@ -266,7 +266,7 @@ func Load(name string) (*Cassette, error) {
 	}
 
 	c.IsNew = false
-	if err := yaml.Unmarshal(data, &c); err != nil {
+	if err := yaml.Unmarshal(data, c); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
The cassete New() initialize cassete and returns a pointer, which can be passed directly to YAML unmarshal.  no need to pass the pointer-to-pointer since its already initialized.

The cassete load panics with nil pointer exception with me. In this case, the issue seems in the YAML itself but passing a simple pointer solve here.

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x20 pc=0x1076e32]

goroutine 7 [running]:
testing.tRunner.func1.2({0x109f9e0, 0x12c3290})
        C:/Program Files/Go/src/testing/testing.go:1526 +0x24e
testing.tRunner.func1()
        C:/Program Files/Go/src/testing/testing.go:1529 +0x39f
panic({0x109f9e0, 0x12c3290})
        C:/Program Files/Go/src/runtime/panic.go:884 +0x213
gopkg.in/dnaeon/go-vcr.v3/cassette.Load({0xc000f06960, 0x2c})
        C:/Users/asadrahman/go/pkg/mod/gopkg.in/dnaeon/go-vcr.v3@v3.1.2/cassette/cassette.go:280 +0xb2

...
...
```