### PR TITLE
on error, report which cassette was not found

### DIFF
--- a/recorder/recorder.go
+++ b/recorder/recorder.go
@@ -29,6 +29,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httputil"
@@ -210,7 +211,7 @@ func NewWithOptions(opts *Options) (*Recorder, error) {
 		rec.cassette = c
 		return rec, nil
 	case opts.Mode == ModeReplayOnly && !cassetteExists:
-		return nil, cassette.ErrCassetteNotFound
+		return nil, fmt.Errorf("%w: %s", cassette.ErrCassetteNotFound, cassetteFile)
 	case opts.Mode == ModeReplayOnly && cassetteExists:
 		c, err := cassette.Load(opts.CassetteName)
 		if err != nil {

--- a/recorder/recorder_test.go
+++ b/recorder/recorder_test.go
@@ -28,6 +28,7 @@ package recorder_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -238,7 +239,7 @@ func TestReplayOnlyModeFailsWithMissingCassette(t *testing.T) {
 		Mode:         recorder.ModeReplayOnly,
 	}
 	_, err := recorder.NewWithOptions(opts)
-	if err != cassette.ErrCassetteNotFound {
+	if !errors.Is(err, cassette.ErrCassetteNotFound) {
 		t.Fatalf("expected cassette.ErrCassetteNotFound, got %v", err)
 	}
 }


### PR DESCRIPTION
Before:

    requested cassette not found

After:

    requested cassette not found: FILENAME

There is a caveat: this change tries to be as backwards compatible as possible, but, as the change in `recorder_test.go` shows, it breaks direct (`!=`) comparison with the sentinel error. On the other hand, one could argue that sentinel errors should always be compared with `errors.Is()`...

In case you are not comfortable accepting this PR, no problems!

Thanks for go-vcr, everybody I show it to starts using it :-)