### PR TITLE
Add server-side recording and test replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ defer r.Stop() // Make sure recorder is stopped once done with it
 ## Server Side
 
 VCR testing can also be used for creating server-side tests. Use the
-`recorder.Middleware` with an HTTP handler in order to create fixtures from
+`recorder.HTTPMiddleware` with an HTTP handler in order to create fixtures from
 incoming requests and the handler's responses. Then, these requests can be
 replayed and compared against the recorded responses to create a regression test.
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,18 @@ defer r.Stop() // Make sure recorder is stopped once done with it
 ...
 ```
 
+## Server Side
+
+VCR testing can also be used for creating server-side tests. Use the
+`recorder.Middleware` with an HTTP handler in order to create fixtures from
+incoming requests and the handler's responses. Then, these requests can be
+replayed and compared against the recorded responses to create a regression test.
+
+Rather than mocking/recording external HTTP interactions, this will record and
+replay _incoming_ interactions with your application's HTTP server.
+
+See [an example here](./examples/middleware_test.go).
+
 ## License
 
 `go-vcr` is Open Source and licensed under the [BSD

--- a/examples/fixtures/middleware.yaml
+++ b/examples/fixtures/middleware.yaml
@@ -9,8 +9,8 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: 127.0.0.1:58027
-        remote_addr: 127.0.0.1:58028
+        host: 127.0.0.1:60761
+        remote_addr: 127.0.0.1:60762
         request_uri: /request1
         body: ""
         form: {}
@@ -37,7 +37,7 @@ interactions:
                 - VALUE
         status: 200 OK
         code: 200
-        duration: 83ns
+        duration: 42ns
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,8 +46,8 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: 127.0.0.1:58027
-        remote_addr: 127.0.0.1:58029
+        host: 127.0.0.1:60761
+        remote_addr: 127.0.0.1:60763
         request_uri: /request2
         body: ""
         form: {}
@@ -67,6 +67,90 @@ interactions:
         content_length: -1
         uncompressed: false
         body: OK
+        headers:
+            Content-Type:
+                - text/plain; charset=utf-8
+            Key:
+                - VALUE
+        status: 200 OK
+        code: 200
+        duration: 41ns
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 9
+        transfer_encoding: []
+        trailer: {}
+        host: 127.0.0.1:60761
+        remote_addr: 127.0.0.1:60764
+        request_uri: /postform
+        body: key=value
+        form:
+            key:
+                - value
+        headers:
+            Accept-Encoding:
+                - gzip
+            Content-Length:
+                - "9"
+            Content-Type:
+                - application/x-www-form-urlencoded
+            User-Agent:
+                - Go-http-client/1.1
+        url: http://go-vcr/postform
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: key=value
+        headers:
+            Content-Type:
+                - text/plain; charset=utf-8
+            Key:
+                - VALUE
+        status: 200 OK
+        code: 200
+        duration: 375ns
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 15
+        transfer_encoding: []
+        trailer: {}
+        host: 127.0.0.1:60761
+        remote_addr: 127.0.0.1:60765
+        request_uri: /postdata
+        body: '{"key":"value"}'
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            Content-Length:
+                - "15"
+            Content-Type:
+                - application/json
+            User-Agent:
+                - Go-http-client/1.1
+        url: http://go-vcr/postdata
+        method: POST
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: '{"key":"value"}'
         headers:
             Content-Type:
                 - text/plain; charset=utf-8

--- a/examples/fixtures/middleware.yaml
+++ b/examples/fixtures/middleware.yaml
@@ -1,0 +1,77 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 127.0.0.1:58027
+        remote_addr: 127.0.0.1:58028
+        request_uri: /request1
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            User-Agent:
+                - Go-http-client/1.1
+        url: http://go-vcr/request1
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: OK
+        headers:
+            Content-Type:
+                - text/plain; charset=utf-8
+            Key:
+                - VALUE
+        status: 200 OK
+        code: 200
+        duration: 83ns
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: 127.0.0.1:58027
+        remote_addr: 127.0.0.1:58029
+        request_uri: /request2
+        body: ""
+        form: {}
+        headers:
+            Accept-Encoding:
+                - gzip
+            User-Agent:
+                - Go-http-client/1.1
+        url: http://go-vcr/request2
+        method: GET
+      response:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: false
+        body: OK
+        headers:
+            Content-Type:
+                - text/plain; charset=utf-8
+            Key:
+                - VALUE
+        status: 200 OK
+        code: 200
+        duration: 125ns

--- a/examples/fixtures/middleware.yaml
+++ b/examples/fixtures/middleware.yaml
@@ -9,8 +9,8 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: 127.0.0.1:60761
-        remote_addr: 127.0.0.1:60762
+        host: ""
+        remote_addr: ""
         request_uri: /request1
         body: ""
         form: {}
@@ -37,7 +37,7 @@ interactions:
                 - VALUE
         status: 200 OK
         code: 200
-        duration: 42ns
+        duration: 0s
     - id: 1
       request:
         proto: HTTP/1.1
@@ -46,9 +46,9 @@ interactions:
         content_length: 0
         transfer_encoding: []
         trailer: {}
-        host: 127.0.0.1:60761
-        remote_addr: 127.0.0.1:60763
-        request_uri: /request2
+        host: ""
+        remote_addr: ""
+        request_uri: /request2?query=example
         body: ""
         form: {}
         headers:
@@ -56,7 +56,7 @@ interactions:
                 - gzip
             User-Agent:
                 - Go-http-client/1.1
-        url: http://go-vcr/request2
+        url: http://go-vcr/request2?query=example
         method: GET
       response:
         proto: HTTP/1.1
@@ -66,7 +66,9 @@ interactions:
         trailer: {}
         content_length: -1
         uncompressed: false
-        body: OK
+        body: |-
+            query=example
+            OK
         headers:
             Content-Type:
                 - text/plain; charset=utf-8
@@ -74,7 +76,7 @@ interactions:
                 - VALUE
         status: 200 OK
         code: 200
-        duration: 41ns
+        duration: 0s
     - id: 2
       request:
         proto: HTTP/1.1
@@ -83,8 +85,8 @@ interactions:
         content_length: 9
         transfer_encoding: []
         trailer: {}
-        host: 127.0.0.1:60761
-        remote_addr: 127.0.0.1:60764
+        host: ""
+        remote_addr: ""
         request_uri: /postform
         body: key=value
         form:
@@ -117,7 +119,7 @@ interactions:
                 - VALUE
         status: 200 OK
         code: 200
-        duration: 375ns
+        duration: 0s
     - id: 3
       request:
         proto: HTTP/1.1
@@ -126,8 +128,8 @@ interactions:
         content_length: 15
         transfer_encoding: []
         trailer: {}
-        host: 127.0.0.1:60761
-        remote_addr: 127.0.0.1:60765
+        host: ""
+        remote_addr: ""
         request_uri: /postdata
         body: '{"key":"value"}'
         form: {}
@@ -158,4 +160,4 @@ interactions:
                 - VALUE
         status: 200 OK
         code: 200
-        duration: 125ns
+        duration: 0s

--- a/examples/middleware_test.go
+++ b/examples/middleware_test.go
@@ -1,0 +1,60 @@
+package vcr_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"gopkg.in/dnaeon/go-vcr.v3/cassette"
+	"gopkg.in/dnaeon/go-vcr.v3/recorder"
+)
+
+func TestMiddleware(t *testing.T) {
+	cassetteName := "fixtures/middleware"
+	createHandler := func(middleware func(http.Handler) http.Handler) http.Handler {
+		mux := http.NewServeMux()
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("KEY", "VALUE")
+			w.Write([]byte("OK"))
+		})
+
+		if middleware != nil {
+			handler = middleware(handler).ServeHTTP
+		}
+
+		mux.Handle("/", handler)
+		return mux
+	}
+
+	t.Run("RecordRealInteractionsWithMiddleware", func(t *testing.T) {
+		recorder, err := recorder.NewWithOptions(&recorder.Options{
+			CassetteName: cassetteName,
+			Mode:         recorder.ModeRecordOnly,
+		})
+		if err != nil {
+			t.Errorf("error creating recorder: %v", err)
+		}
+
+		// Create the server handler with recorder middleware
+		handler := createHandler(recorder.Middleware)
+		defer recorder.Stop()
+
+		server := httptest.NewServer(handler)
+		defer server.Close()
+
+		_, err = http.Get(server.URL + "/request1")
+		if err != nil {
+			t.Errorf("error making request: %v", err)
+		}
+
+		_, err = http.Get(server.URL + "/request2")
+		if err != nil {
+			t.Errorf("error making request: %v", err)
+		}
+	})
+
+	t.Run("ReplayCassetteAndCompare", func(t *testing.T) {
+		cassette.TestServerReplay(t, cassetteName, createHandler(nil))
+	})
+}

--- a/pkg/cassette/cassette.go
+++ b/pkg/cassette/cassette.go
@@ -324,6 +324,13 @@ func (m *defaultMatcher) matcher(r *http.Request, i Request) bool {
 		return false
 	}
 
+	// Only ParseForm for non-GET requests since that would use query params
+	if r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodPatch {
+		err := r.ParseForm()
+		if err != nil {
+			return false
+		}
+	}
 	if !m.deepEqualContents(r.Form, i.Form) {
 		return false
 	}

--- a/pkg/cassette/server_replay.go
+++ b/pkg/cassette/server_replay.go
@@ -1,0 +1,82 @@
+package cassette
+
+import (
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+)
+
+// TestServerReplay loads a Cassette and replays each Interaction with the provided Handler, then compares the response
+func TestServerReplay(t *testing.T, cassetteName string, handler http.Handler) {
+	t.Helper()
+
+	c, err := Load(cassetteName)
+	if err != nil {
+		t.Errorf("unexpected error loading Cassette: %v", err)
+	}
+
+	if len(c.Interactions) == 0 {
+		t.Error("no interactions in Cassette")
+	}
+
+	for _, interaction := range c.Interactions {
+		t.Run(fmt.Sprintf("Interaction_%d", interaction.ID), func(t *testing.T) {
+			TestInteractionReplay(t, handler, interaction)
+		})
+	}
+}
+
+// TestInteractionReplay replays an Interaction with the provided Handler and compares the response
+func TestInteractionReplay(t *testing.T, handler http.Handler, interaction *Interaction) {
+	t.Helper()
+
+	req, err := interaction.GetHTTPRequest()
+	if err != nil {
+		t.Errorf("unexpected error getting interaction request: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	expectedResp, err := interaction.GetHTTPResponse()
+	if err != nil {
+		t.Errorf("unexpected error getting interaction response: %v", err)
+	}
+
+	if expectedResp.StatusCode != w.Result().StatusCode {
+		t.Errorf("status code does not match: expected=%d actual=%d", expectedResp.StatusCode, w.Result().StatusCode)
+	}
+
+	expectedBody, err := io.ReadAll(expectedResp.Body)
+	if err != nil {
+		t.Errorf("unexpected reading response body: %v", err)
+	}
+
+	if string(expectedBody) != w.Body.String() {
+		t.Errorf("body does not match: expected=%s actual=%s", expectedBody, w.Body.String())
+	}
+
+	if !headersEqual(expectedResp.Header, w.Header()) {
+		t.Errorf("header values do not match. expected=%v actual=%v", expectedResp.Header, w.Header())
+	}
+}
+
+func headersEqual(expected, actual http.Header) bool {
+	return maps.EqualFunc(
+		expected, actual,
+		func(v1, v2 []string) bool {
+			slices.Sort(v1)
+			slices.Sort(v2)
+
+			if !slices.Equal(v1, v2) {
+				return false
+			}
+
+			return true
+		},
+	)
+}

--- a/pkg/cassette/server_replay.go
+++ b/pkg/cassette/server_replay.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -37,6 +38,10 @@ func TestInteractionReplay(t *testing.T, handler http.Handler, interaction *Inte
 	req, err := interaction.GetHTTPRequest()
 	if err != nil {
 		t.Errorf("unexpected error getting interaction request: %v", err)
+	}
+
+	if len(req.Form) > 0 {
+		req.Body = io.NopCloser(strings.NewReader(req.Form.Encode()))
 	}
 
 	w := httptest.NewRecorder()

--- a/pkg/recorder/middleware.go
+++ b/pkg/recorder/middleware.go
@@ -1,0 +1,54 @@
+package recorder
+
+import (
+	"net/http"
+	"net/http/httptest"
+)
+
+// Middleware intercepts and records all incoming requests and the server's response
+func (rec *Recorder) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ww := newPassthrough(w)
+		next.ServeHTTP(ww, r)
+
+		// On the server side, requests do not have Host and Scheme so it must be set
+		r.URL.Host = "go-vcr"
+		r.URL.Scheme = "http"
+
+		// copy headers from real response
+		for k, vv := range ww.real.Header() {
+			for _, v := range vv {
+				ww.recorder.Result().Header.Add(k, v)
+			}
+		}
+
+		_, _ = rec.executeAndRecord(r, ww.recorder.Result())
+	})
+}
+
+var _ http.ResponseWriter = &passthroughWriter{}
+
+// passthroughWriter uses the original ResponseWriter and an httptest.ResponseRecorder
+// so the middleware can capture response details and passthrough to the client
+type passthroughWriter struct {
+	recorder *httptest.ResponseRecorder
+	real     http.ResponseWriter
+}
+
+func newPassthrough(real http.ResponseWriter) passthroughWriter {
+	return passthroughWriter{recorder: httptest.NewRecorder(), real: real}
+}
+
+func (p passthroughWriter) Header() http.Header {
+	return p.real.Header()
+}
+
+func (p passthroughWriter) Write(in []byte) (int, error) {
+	_, _ = p.recorder.Write(in)
+	return p.real.Write(in)
+}
+
+func (p passthroughWriter) WriteHeader(statusCode int) {
+	p.recorder.WriteHeader(statusCode)
+	p.real.WriteHeader(statusCode)
+}

--- a/pkg/recorder/middleware.go
+++ b/pkg/recorder/middleware.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 )
 
-// Middleware intercepts and records all incoming requests and the server's response
-func (rec *Recorder) Middleware(next http.Handler) http.Handler {
+// HTTPMiddleware intercepts and records all incoming requests and the server's response
+func (rec *Recorder) HTTPMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ww := newPassthrough(w)
 

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -586,7 +586,7 @@ func (rec *Recorder) RoundTrip(req *http.Request) (*http.Response, error) {
 	return rec.executeAndRecord(req, nil)
 }
 
-// executeAndRecord is used internally by the Middleware to allow recording a response on the server side
+// executeAndRecord is used internally by the HTTPMiddleware to allow recording a response on the server side
 func (rec *Recorder) executeAndRecord(req *http.Request, serverResponse *http.Response) (*http.Response, error) {
 	// Passthrough mode, use real transport
 	if rec.mode == ModePassthrough {

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -453,6 +453,11 @@ func (rec *Recorder) requestHandler(r *http.Request, serverResponse *http.Respon
 	if r.Body != nil && r.Body != http.NoBody {
 		// Record the request body so we can add it to the cassette
 		r.Body = io.NopCloser(io.TeeReader(r.Body, reqBody))
+		if serverResponse != nil {
+			// when serverResponse is provided by middleware, it has to be read in order
+			// for reqBody buffer to be populated
+			_, _ = io.ReadAll(r.Body)
+		}
 	}
 
 	// Perform request to it's original destination and record the interactions


### PR DESCRIPTION
## Description
Rather than mocking/recording external HTTP interactions, this enables recording and replaying _incoming_ interactions with your application's HTTP server.

This works by putting the `Recorder` in a middleware and uses the existing code for recording request/response. Instead of using a `RoundTripper` to get the response, the middleware provides the underlying handler's actual response.

Then, a few methods are added to the `cassette` package for replaying and testing the recorded interactions.

No breaking changes.

## More details

Hello! Thanks for creating such a great library for testing HTTP clients.

I have a need for doing something similar on the server-side to record interactions and convert them into regression tests. Initially I was able to create a separate library that wraps the `Recorder` to achieve this, but realized it will be better if I integrate it directly, especially after seeing #88.

If I create this as a separate library/package, then I have to use `rec.SetRealTransport` for each request in the middleware which likely isn't safe for concurrent use.

I expect to receive some feedback and discussion as part of this PR, so I am open to any suggestions on how to make this a better fit for the library.

Lastly, no hard feelings if you choose to decline this PR 🙂 