### PR TITLE
Add option to matcher to ignore authorization header

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ hook := func(i *cassette.Interaction) error {
 opts := []recorder.Option{
 	recorder.WithCassette("fixtures/filters"),
 	recorder.WithHook(hook, recorder.AfterCaptureHook),
+	recorder.WithMatcher(cassette.NewDefaultMatcher(cassette.WithIgnoreAuthorization(true))),
 }
 
 r, err := recorder.New(opts...)

--- a/pkg/cassette/cassette_test.go
+++ b/pkg/cassette/cassette_test.go
@@ -250,4 +250,22 @@ func TestMatcher(t *testing.T) {
 			}
 		})
 	})
+
+	t.Run("IgnoreAuthorization=true", func(t *testing.T) {
+		matcherFn := NewDefaultMatcher(WithIgnoreAuthorization(true))
+
+		t.Run("match", func(t *testing.T) {
+			r, i := getMatcherRequests(t)
+
+			r.Header = http.Header{
+				"Authorization": {"Bearer xyz"},
+			}
+
+			i.Headers = http.Header{}
+
+			if b := matcherFn(r, i); !b {
+				t.Fatalf("request should have matched")
+			}
+		})
+	})
 }


### PR DESCRIPTION
The suggestion in the readme to clear authorization headers in hooks isn't working for us; when we attempt to run against the recorded cassettes the match fails as the http.Request has an Authorization header that the cassette interaction doesn't.