### PR TITLE
Add option to matcher to ignore headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ hook := func(i *cassette.Interaction) error {
 opts := []recorder.Option{
 	recorder.WithCassette("fixtures/filters"),
 	recorder.WithHook(hook, recorder.AfterCaptureHook),
-	recorder.WithMatcher(cassette.NewDefaultMatcher(cassette.WithIgnoreAuthorization(true))),
+	recorder.WithMatcher(cassette.NewDefaultMatcher(cassette.WithIgnoreAuthorization())),
 }
 
 r, err := recorder.New(opts...)

--- a/pkg/cassette/cassette_test.go
+++ b/pkg/cassette/cassette_test.go
@@ -231,8 +231,8 @@ func TestMatcher(t *testing.T) {
 		})
 	})
 
-	t.Run("IgnoreUserAgent=true", func(t *testing.T) {
-		matcherFn := NewDefaultMatcher(WithIgnoreUserAgent(true))
+	t.Run("IgnoreUserAgent", func(t *testing.T) {
+		matcherFn := NewDefaultMatcher(WithIgnoreUserAgent())
 
 		t.Run("match", func(t *testing.T) {
 			r, i := getMatcherRequests(t)
@@ -251,8 +251,8 @@ func TestMatcher(t *testing.T) {
 		})
 	})
 
-	t.Run("IgnoreAuthorization=true", func(t *testing.T) {
-		matcherFn := NewDefaultMatcher(WithIgnoreAuthorization(true))
+	t.Run("IgnoreAuthorization", func(t *testing.T) {
+		matcherFn := NewDefaultMatcher(WithIgnoreAuthorization())
 
 		t.Run("match", func(t *testing.T) {
 			r, i := getMatcherRequests(t)
@@ -262,6 +262,30 @@ func TestMatcher(t *testing.T) {
 			}
 
 			i.Headers = http.Header{}
+
+			if b := matcherFn(r, i); !b {
+				t.Fatalf("request should have matched")
+			}
+		})
+	})
+
+	t.Run("IgnoreHeaders", func(t *testing.T) {
+		matcherFn := NewDefaultMatcher(WithIgnoreHeaders("Header-One", "Header-Two"), WithIgnoreUserAgent(), WithIgnoreAuthorization())
+
+		t.Run("match", func(t *testing.T) {
+			r, i := getMatcherRequests(t)
+
+			r.Header = http.Header{
+				"Header-One": {"foo"},
+				"Header-Two": {"foo"},
+				"User-Agent": {"foo", "bar"},
+			}
+
+			i.Headers = http.Header{
+				"Header-One":    {"bar"},
+				"Header-Two":    {"bar"},
+				"Authorization": {"Bearer xyz"},
+			}
 
 			if b := matcherFn(r, i); !b {
 				t.Fatalf("request should have matched")


### PR DESCRIPTION
The new matcher, which is more strict now, is breaking tests where some of the headers are skipped (like secrets) or change on each request (like tracing spans). The cassete already supports the User-Agentt, and the Authorization has also been added but not released yet.

In order to make it more generic and usable for people, I've added a more generic implementation of these options, which will allow us to define which headers we really want to ignore.