### PR TITLE
Set the request.Body to http.NoBody if request.Body is nil

### DIFF
--- a/pkg/cassette/cassette.go
+++ b/pkg/cassette/cassette.go
@@ -459,6 +459,11 @@ func (c *Cassette) GetInteraction(r *http.Request) (*Interaction, error) {
 func (c *Cassette) getInteraction(r *http.Request) (*Interaction, error) {
 	c.Lock()
 	defer c.Unlock()
+	if r.Body == nil {
+		// causes an error in the matcher when we try to do r.ParseForm if r.Body is nil
+		// r.ParseForm returns missing form body error
+		r.Body = http.NoBody
+	}
 	for _, i := range c.Interactions {
 		if (c.ReplayableInteractions || !i.replayed) && c.Matcher(r, i.Request) {
 			i.replayed = true


### PR DESCRIPTION
I noticed that on certain requests I get a missing interaction error. But looking at the yaml file the interaction is there.
I tracked it down to certain Post requests that do no have any body. So when the replay matches the body is nil, and r.ParseForm returns an error when it shouldn't. 

https://github.com/dnaeon/go-vcr/blob/e544a7e468e5bd51652002be6cfd6ee604f945b0/pkg/cassette/cassette.go#L345C1-L352C1

and the error is raised 

https://cs.opensource.google/go/go/+/refs/tags/go1.23.2:src/net/http/request.go;l=1272-1276;drc=29b1a6765fb5f124171d94f157b6d6c3b2687468

An example of what causes the error to occur.

https://github.com/ilijamt/vault-plugin-secrets-gitlab/blob/33f02606e7871715fb682d08b8a7232e40720eab/testdata/fixtures/16.11.6/TestWithServiceAccountUser.yaml