### PR TITLE
cassette: wrap ErrCassetteNotFound with the number of errors

### DIFF
--- a/pkg/cassette/cassette.go
+++ b/pkg/cassette/cassette.go
@@ -51,12 +51,12 @@ var (
 	// found in the cassette file.
 	ErrInteractionNotFound = errors.New("requested interaction not found")
 
-	// ErrCassetteNotFound indicates that a requested casette doesn't exist.
+	// ErrCassetteNotFound indicates that a requested cassette doesn't exist.
 	ErrCassetteNotFound = errors.New("requested cassette not found")
 
 	// ErrUnsupportedCassetteFormat is returned when attempting to use an
 	// older and potentially unsupported format of a cassette.
-	ErrUnsupportedCassetteFormat = fmt.Errorf("unsupported cassette version format")
+	ErrUnsupportedCassetteFormat = errors.New("unsupported cassette version format")
 )
 
 // Request represents a client request as recorded in the cassette file.
@@ -464,14 +464,17 @@ func (c *Cassette) getInteraction(r *http.Request) (*Interaction, error) {
 		// r.ParseForm returns missing form body error
 		r.Body = http.NoBody
 	}
+	replayed := 0
 	for _, i := range c.Interactions {
+		if i.replayed {
+			replayed++
+		}
 		if (c.ReplayableInteractions || !i.replayed) && c.Matcher(r, i.Request) {
 			i.replayed = true
 			return i, nil
 		}
 	}
-
-	return nil, ErrInteractionNotFound
+	return nil, fmt.Errorf("%w for after %d playbacks", ErrInteractionNotFound, replayed)
 }
 
 // Save writes the cassette data on disk for future re-use

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -390,7 +390,7 @@ func (rec *Recorder) requestHandler(r *http.Request, serverResponse *http.Respon
 		if err == nil {
 			// Interaction found, return it
 			return interaction, nil
-		} else if err == cassette.ErrInteractionNotFound {
+		} else if errors.Is(err, cassette.ErrInteractionNotFound) {
 			// Interaction not found, we have a new episode
 			break
 		} else {
@@ -411,7 +411,7 @@ func (rec *Recorder) requestHandler(r *http.Request, serverResponse *http.Respon
 		if err == nil {
 			// Interaction found, return it
 			return interaction, nil
-		} else if err == cassette.ErrInteractionNotFound {
+		} else if errors.Is(err, cassette.ErrInteractionNotFound) {
 			// Interaction not found, we have to record it
 			break
 		} else {

--- a/pkg/recorder/recorder_test.go
+++ b/pkg/recorder/recorder_test.go
@@ -214,7 +214,6 @@ func TestRecordOnceMode(t *testing.T) {
 		recordedStatus := c.Interactions[i].Response.Code
 		if test.wantStatus != recordedStatus {
 			t.Fatalf("got recorded status: %q, want recorded status: %q", test.wantStatus, recordedStatus)
-
 		}
 	}
 
@@ -420,7 +419,7 @@ func TestRecordOnceWithMissingEpisodes(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected err but was %T %s", err, err)
 		}
-		if urlErr.Err != cassette.ErrInteractionNotFound {
+		if !errors.Is(urlErr.Err, cassette.ErrInteractionNotFound) {
 			t.Fatalf("expected cassette.ErrInteractionNotFound but was %T %s", err, err)
 		}
 	}


### PR DESCRIPTION
Use errors.Is() instead of equality.