### PR TITLE
Always call http.Request.ParseForm method

### DIFF
--- a/examples/testdata/go-dev.yaml
+++ b/examples/testdata/go-dev.yaml
@@ -8,6 +8,9 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: go.dev
+        form:
+            m:
+                - text
         url: https://go.dev/VERSION?m=text
         method: GET
       response:
@@ -17,15 +20,15 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            go1.24.1
-            time 2025-02-27T17:57:18Z
+            go1.24.4
+            time 2025-05-29T19:37:36Z
         headers:
             Content-Security-Policy:
                 - 'connect-src ''self'' www.google-analytics.com stats.g.doubleclick.net ; default-src ''self'' ; font-src ''self'' fonts.googleapis.com fonts.gstatic.com data: ; frame-ancestors ''self'' ; frame-src ''self'' www.google.com feedback.googleusercontent.com www.googletagmanager.com scone-pa.clients6.google.com www.youtube.com player.vimeo.com ; img-src ''self'' www.google.com www.google-analytics.com ssl.gstatic.com www.gstatic.com gstatic.com data: * ; object-src ''none'' ; script-src ''self'' ''sha256-n6OdwTrm52KqKm6aHYgD0TFUdMgww4a0GQlIAVrMzck='' ''sha256-4ryYrf7Y5daLOBv0CpYtyBIcJPZkRD2eBPdfqsN3r1M='' ''sha256-sVKX08+SqOmnWhiySYk3xC7RDUgKyAkmbXV2GWts4fo='' www.google.com apis.google.com www.gstatic.com gstatic.com support.google.com www.googletagmanager.com www.google-analytics.com ssl.google-analytics.com tagmanager.google.com ; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com feedback.googleusercontent.com www.gstatic.com gstatic.com tagmanager.google.com ;'
             Content-Type:
                 - text/plain; charset=utf-8
             Date:
-                - Fri, 21 Mar 2025 19:00:24 GMT
+                - Fri, 27 Jun 2025 08:29:27 GMT
             Server:
                 - Google Frontend
             Strict-Transport-Security:
@@ -33,7 +36,7 @@ interactions:
             Vary:
                 - Accept-Encoding
             X-Cloud-Trace-Context:
-                - c5713298a89696e8e768726811889751
+                - bf9a2144badb1172ba7aa1a1424e58e2
         status: 200 OK
         code: 200
-        duration: 122.635855ms
+        duration: 229.432625ms

--- a/pkg/cassette/cassette.go
+++ b/pkg/cassette/cassette.go
@@ -342,13 +342,10 @@ func (m *defaultMatcher) matcher(r *http.Request, i Request) bool {
 		return false
 	}
 
-	// Only ParseForm for non-GET requests since that would use query params
-	if r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodPatch {
-		err := r.ParseForm()
-		if err != nil {
-			return false
-		}
+	if err := r.ParseForm(); err != nil {
+		return false
 	}
+
 	if !m.deepEqualContents(r.Form, i.Form) {
 		return false
 	}
@@ -474,7 +471,7 @@ func (c *Cassette) getInteraction(r *http.Request) (*Interaction, error) {
 			return i, nil
 		}
 	}
-	return nil, fmt.Errorf("%w for after %d playbacks", ErrInteractionNotFound, replayed)
+	return nil, ErrInteractionNotFound
 }
 
 // Save writes the cassette data on disk for future re-use

--- a/pkg/recorder/recorder_test.go
+++ b/pkg/recorder/recorder_test.go
@@ -148,6 +148,14 @@ func TestRecordOnceMode(t *testing.T) {
 			wantContentLength: 15,
 			path:              "/api/v1/qux",
 		},
+		{
+			method:            http.MethodPut,
+			body:              "foobar",
+			wantBody:          "PUT go-vcr\nfoobar",
+			wantStatus:        http.StatusOK,
+			wantContentLength: 17,
+			path:              "/api/v1/foobar?foo=bar&baz=qux",
+		},
 	}
 
 	server := newEchoHttpServer()

--- a/pkg/recorder/testdata/hello-world.yaml
+++ b/pkg/recorder/testdata/hello-world.yaml
@@ -8,6 +8,9 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: go.dev
+        form:
+            m:
+                - text
         url: https://go.dev/VERSION?m=text
         method: GET
       response:
@@ -17,15 +20,15 @@ interactions:
         content_length: -1
         uncompressed: true
         body: |
-            go1.24.1
-            time 2025-02-27T17:57:18Z
+            go1.24.4
+            time 2025-05-29T19:37:36Z
         headers:
             Content-Security-Policy:
                 - 'connect-src ''self'' www.google-analytics.com stats.g.doubleclick.net ; default-src ''self'' ; font-src ''self'' fonts.googleapis.com fonts.gstatic.com data: ; frame-ancestors ''self'' ; frame-src ''self'' www.google.com feedback.googleusercontent.com www.googletagmanager.com scone-pa.clients6.google.com www.youtube.com player.vimeo.com ; img-src ''self'' www.google.com www.google-analytics.com ssl.gstatic.com www.gstatic.com gstatic.com data: * ; object-src ''none'' ; script-src ''self'' ''sha256-n6OdwTrm52KqKm6aHYgD0TFUdMgww4a0GQlIAVrMzck='' ''sha256-4ryYrf7Y5daLOBv0CpYtyBIcJPZkRD2eBPdfqsN3r1M='' ''sha256-sVKX08+SqOmnWhiySYk3xC7RDUgKyAkmbXV2GWts4fo='' www.google.com apis.google.com www.gstatic.com gstatic.com support.google.com www.googletagmanager.com www.google-analytics.com ssl.google-analytics.com tagmanager.google.com ; style-src ''self'' ''unsafe-inline'' fonts.googleapis.com feedback.googleusercontent.com www.gstatic.com gstatic.com tagmanager.google.com ;'
             Content-Type:
                 - text/plain; charset=utf-8
             Date:
-                - Fri, 21 Mar 2025 18:54:09 GMT
+                - Fri, 27 Jun 2025 08:28:38 GMT
             Server:
                 - Google Frontend
             Strict-Transport-Security:
@@ -33,7 +36,7 @@ interactions:
             Vary:
                 - Accept-Encoding
             X-Cloud-Trace-Context:
-                - 456239e0753b67424048ab478ab7e78f
+                - dc4758d24bd970f245e301e0d9092399
         status: 200 OK
         code: 200
-        duration: 125.432436ms
+        duration: 415.835458ms


### PR DESCRIPTION
Always call `http.Request.ParseForm`, so that `Form` and `PostForm` are populated.

Fix for #121, which was caused by #118.

> [!NOTE] 
> Cassettes may need to be re-created.

cc: @hectorj-thetreep , @maruel , @ilijamt 