### PR TITLE
new: allow to store cassette in any data source

### DIFF
--- a/pkg/cassette/cassette.go
+++ b/pkg/cassette/cassette.go
@@ -31,8 +31,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -418,8 +416,13 @@ func New(name string) *Cassette {
 
 // Load reads a cassette file from disk
 func Load(name string) (*Cassette, error) {
+	return LoadWithFS(name, NewDiskFS())
+}
+
+// Load reads a cassette file from disk
+func LoadWithFS(name string, fs FS) (*Cassette, error) {
 	c := New(name)
-	data, err := os.ReadFile(c.File)
+	data, err := fs.ReadFile(c.File)
 	if err != nil {
 		return nil, err
 	}
@@ -476,16 +479,13 @@ func (c *Cassette) getInteraction(r *http.Request) (*Interaction, error) {
 
 // Save writes the cassette data on disk for future re-use
 func (c *Cassette) Save() error {
+	return c.SaveWithFS(NewDiskFS())
+}
+
+// SaveWithFS writes the cassette data on abstract filesystem for future re-use
+func (c *Cassette) SaveWithFS(fs FS) error {
 	c.Lock()
 	defer c.Unlock()
-
-	// Create directory for cassette if missing
-	cassetteDir := filepath.Dir(c.File)
-	if _, err := os.Stat(cassetteDir); os.IsNotExist(err) {
-		if err = os.MkdirAll(cassetteDir, 0o755); err != nil {
-			return err
-		}
-	}
 
 	// Filter out interactions which should be discarded. While discarding
 	// interactions we should also fix the interaction IDs, so that we don't
@@ -507,24 +507,7 @@ func (c *Cassette) Save() error {
 		return err
 	}
 
-	f, err := os.Create(c.File)
-	if err != nil {
-		return err
-	}
-
-	defer f.Close()
-
 	// Honor the YAML structure specification
 	// http://www.yaml.org/spec/1.2/spec.html#id2760395
-	_, err = f.Write([]byte("---\n"))
-	if err != nil {
-		return err
-	}
-
-	_, err = f.Write(data)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return fs.WriteFile(c.File, append([]byte("---\n"), data...))
 }

--- a/pkg/cassette/fs.go
+++ b/pkg/cassette/fs.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2015-2024 Marin Atanasov Nikolov <dnaeon@gmail.com>
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer
+//    in this position and unchanged.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+// IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+// NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package cassette
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// FS defines a generic filesystem interface.
+// It allows to redefine storage without depending on a specific filesystem implementation.
+type FS interface {
+	// ReadFile reads the contents of the file named by 'name'.
+	ReadFile(name string) ([]byte, error)
+
+	// WriteFile writes 'data' to the file named by 'name'.
+	WriteFile(name string, data []byte) error
+
+	// IsFileExists checks whether a file with the given 'name' exists.
+	IsFileExists(name string) bool
+}
+
+// NewDiskFS creates and returns a new FS implementation backed by the local disk filesystem.
+func NewDiskFS() FS {
+	return &diskFS{}
+}
+
+type diskFS struct{}
+
+func (fs *diskFS) ReadFile(name string) ([]byte, error) {
+	return os.ReadFile(name)
+}
+
+func (fs *diskFS) WriteFile(name string, data []byte) error {
+	cassetteDir := filepath.Dir(name)
+	if _, err := os.Stat(cassetteDir); os.IsNotExist(err) {
+		if err = os.MkdirAll(cassetteDir, 0o755); err != nil {
+			return err
+		}
+	}
+
+	f, err := os.Create(name)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+	_, err = f.Write(data)
+	return err
+}
+
+func (fs *diskFS) IsFileExists(name string) bool {
+	_, err := os.Stat(name)
+	return !os.IsNotExist(err)
+}

--- a/pkg/cassette/server_replay.go
+++ b/pkg/cassette/server_replay.go
@@ -32,8 +32,15 @@ var DefaultReplayAssertFunc ReplayAssertFunc = func(t *testing.T, expected *Inte
 // TestServerReplay loads a Cassette and replays each Interaction with the provided Handler, then compares the response
 func TestServerReplay(t *testing.T, cassetteName string, handler http.Handler) {
 	t.Helper()
+	TestServerReplayWithFS(t, cassetteName, NewDiskFS(), handler)
+}
 
-	c, err := Load(cassetteName)
+// TestServerReplayWithFS loads a Cassette and replays each Interaction with the provided Handler, then compares the response.
+// Function reads replay from abstract file system.
+func TestServerReplayWithFS(t *testing.T, cassetteName string, fs FS, handler http.Handler) {
+	t.Helper()
+
+	c, err := LoadWithFS(cassetteName, fs)
 	if err != nil {
 		t.Errorf("unexpected error loading Cassette: %v", err)
 	}

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -33,7 +33,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httputil"
-	"os"
 	"time"
 
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
@@ -207,6 +206,9 @@ type Recorder struct {
 	// replayableInteractions specifies whether to allow interactions to be
 	// replayed multiple times.
 	replayableInteractions bool
+
+	// fs specifies custom filesystem ([cassette.FS]) implementation.
+	fs cassette.FS
 }
 
 // Option is a function which configures the [Recorder].
@@ -300,6 +302,17 @@ func WithReplayableInteractions(val bool) Option {
 	return opt
 }
 
+// WithFS is an [Option], which configures the [Recorder] to use
+// custom filesystem ([cassette.FS]) implementation. This allows the [Recorder] to use any
+// FS-compatible backend (e.g., local disk, in-memory, or mock) for reading and writing files.
+func WithFS(fs cassette.FS) Option {
+	opt := func(r *Recorder) {
+		r.fs = fs
+	}
+
+	return opt
+}
+
 // New creates a new [Recorder] and configures it using the provided options.
 func New(cassetteName string, opts ...Option) (*Recorder, error) {
 	r := &Recorder{
@@ -312,6 +325,7 @@ func New(cassetteName string, opts ...Option) (*Recorder, error) {
 		skipRequestLatency:     false,
 		matcher:                cassette.DefaultMatcher,
 		replayableInteractions: false,
+		fs:                     cassette.NewDiskFS(),
 	}
 
 	for _, opt := range opts {
@@ -339,8 +353,7 @@ func (rec *Recorder) getCassette() (*cassette.Cassette, error) {
 
 	// Create or the cassette depending on the mode we are operating in.
 	cassetteFile := cassette.New(rec.cassetteName).File
-	_, err := os.Stat(cassetteFile)
-	cassetteExists := !os.IsNotExist(err)
+	cassetteExists := rec.fs.IsFileExists(cassetteFile)
 
 	switch {
 	case rec.mode == ModeRecordOnly:
@@ -348,15 +361,15 @@ func (rec *Recorder) getCassette() (*cassette.Cassette, error) {
 	case rec.mode == ModeReplayOnly && !cassetteExists:
 		return nil, fmt.Errorf("%w: %s", cassette.ErrCassetteNotFound, cassetteFile)
 	case rec.mode == ModeReplayOnly && cassetteExists:
-		return cassette.Load(rec.cassetteName)
+		return cassette.LoadWithFS(rec.cassetteName, rec.fs)
 	case rec.mode == ModeReplayWithNewEpisodes && !cassetteExists:
 		return cassette.New(rec.cassetteName), nil
 	case rec.mode == ModeReplayWithNewEpisodes && cassetteExists:
-		return cassette.Load(rec.cassetteName)
+		return cassette.LoadWithFS(rec.cassetteName, rec.fs)
 	case rec.mode == ModeRecordOnce && !cassetteExists:
 		return cassette.New(rec.cassetteName), nil
 	case rec.mode == ModeRecordOnce && cassetteExists:
-		return cassette.Load(rec.cassetteName)
+		return cassette.LoadWithFS(rec.cassetteName, rec.fs)
 	case rec.mode == ModePassthrough:
 		return cassette.New(rec.cassetteName), nil
 	default:
@@ -520,8 +533,7 @@ func (rec *Recorder) requestHandler(r *http.Request, serverResponse *http.Respon
 // running in ModePassthrough no cassette will be saved on disk.
 func (rec *Recorder) Stop() error {
 	cassetteFile := rec.cassette.File
-	_, err := os.Stat(cassetteFile)
-	cassetteExists := !os.IsNotExist(err)
+	cassetteExists := rec.fs.IsFileExists(cassetteFile)
 
 	// Nothing to do for ModeReplayOnly and ModePassthrough here
 	switch {
@@ -555,7 +567,7 @@ func (rec *Recorder) persistCassette() error {
 		}
 	}
 
-	return rec.cassette.Save()
+	return rec.cassette.SaveWithFS(rec.fs)
 }
 
 // applyHooks applies the registered hooks of the given kind with the


### PR DESCRIPTION
introduce virtual filesystem for cassette. It will allow to store them in any storage and solve problem like https://github.com/dnaeon/go-vcr/issues/112 or https://github.com/dnaeon/go-vcr/issues/123