### PR TITLE
feat: add `WithEncodeOption` to tweak yaml marshalling

### DIFF
--- a/pkg/cassette/cassette.go
+++ b/pkg/cassette/cassette.go
@@ -396,6 +396,9 @@ type Cassette struct {
 	IsNew bool `yaml:"-"`
 
 	nextInteractionId int `yaml:"-"`
+
+	// EncodeOptions is an optional list of YAML encoder options.
+	EncodeOptions []yaml.EncodeOption `yaml:"-"`
 }
 
 // New creates a new empty cassette
@@ -502,10 +505,12 @@ func (c *Cassette) SaveWithFS(fs FS) error {
 	c.Interactions = interactions
 
 	// Marshal to YAML and save interactions
-	data, err := yaml.Marshal(c)
-	if err != nil {
+	var buff bytes.Buffer
+	enc := yaml.NewEncoder(&buff, c.EncodeOptions...)
+	if err := enc.Encode(c); err != nil {
 		return err
 	}
+	data := buff.Bytes()
 
 	// Honor the YAML structure specification
 	// http://www.yaml.org/spec/1.2/spec.html#id2760395

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -35,6 +35,7 @@ import (
 	"net/http/httputil"
 	"time"
 
+	"github.com/goccy/go-yaml"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
 )
 
@@ -209,6 +210,8 @@ type Recorder struct {
 
 	// fs specifies custom filesystem ([cassette.FS]) implementation.
 	fs cassette.FS
+
+	encodeOptions []yaml.EncodeOption
 }
 
 // Option is a function which configures the [Recorder].
@@ -313,6 +316,15 @@ func WithFS(fs cassette.FS) Option {
 	return opt
 }
 
+// WithEncodeOptions is an [Option], which configures the [Recorder] to use
+// custom YAML encoder options. This allows customization of the YAML encoding
+// process, such as setting string literal style, etc.
+func WithEncodeOptions(encodeOptions ...yaml.EncodeOption) Option {
+	return func(r *Recorder) {
+		r.encodeOptions = encodeOptions
+	}
+}
+
 // New creates a new [Recorder] and configures it using the provided options.
 func New(cassetteName string, opts ...Option) (*Recorder, error) {
 	r := &Recorder{
@@ -340,6 +352,7 @@ func New(cassetteName string, opts ...Option) (*Recorder, error) {
 	r.cassette = c
 	r.cassette.Matcher = r.matcher
 	r.cassette.ReplayableInteractions = r.replayableInteractions
+	r.cassette.EncodeOptions = r.encodeOptions
 
 	return r, nil
 }


### PR DESCRIPTION
This is a simple change to allow tweaking how YAML is generated, like setting [`UseLiteralStyleIfMultiline`](https://pkg.go.dev/github.com/goccy/go-yaml#UseLiteralStyleIfMultiline) to pretty-print multi-line strings.

```go
r, err := recorder.New(
	cassetteName,
	recorder.WithEncodeOptions(yaml.UseLiteralStyleIfMultiline(true)),
)
```