### PR TITLE
feat: migrate to official yaml package / add `WithMarshalFunc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,31 @@ complete and ready to run examples.
 You can also refer to the [test cases](./pkg/recorder/recorder_test.go) for
 additional examples.
 
+## Custom YAML Marshaling Function
+
+If you need control how YAML is encoded, set `WithMarshalFunc` with a custom
+func. This default to `yaml.Marshal`.
+
+```go
+marshalFunc := func(in any) (out []byte, err error) {
+	var buff bytes.Buffer
+	enc := yaml.NewEncoder(&buff)
+
+	// Example of custom options from
+	// https://pkg.go.dev/go.yaml.in/yaml/v4
+	enc.CompactSeqIndent()
+	enc.SetIndent(4)
+
+	if err := enc.Encode(in); err != nil {
+		return nil, err
+	}
+	return buff.Bytes(), nil
+}
+
+rec, err := recorder.New("cassette_name", recorder.WithMarshalFunc(marshalFunc))
+// ...
+```
+
 ## Custom Request Matching
 
 During replay mode, you can customize the way incoming requests are matched

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module gopkg.in/dnaeon/go-vcr.v4
 
 go 1.24
 
-require github.com/goccy/go-yaml v1.18.0
+require go.yaml.in/yaml/v4 v4.0.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
-github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=
+go.yaml.in/yaml/v4 v4.0.0-rc.2/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=

--- a/pkg/cassette/cassette.go
+++ b/pkg/cassette/cassette.go
@@ -36,7 +36,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/goccy/go-yaml"
+	"go.yaml.in/yaml/v4"
 )
 
 const (
@@ -196,6 +196,9 @@ func (i *Interaction) GetHTTPResponse() (*http.Response, error) {
 // MatcherFunc is a predicate, which returns true when the actual request
 // matches an interaction from the cassette.
 type MatcherFunc func(*http.Request, Request) bool
+
+// MarshalFunc is a function which marshals an object to a byte slice.
+type MarshalFunc func(any) ([]byte, error)
 
 // defaultMatcher is the default matcher used to match HTTP requests with
 // recorded interactions.
@@ -397,8 +400,8 @@ type Cassette struct {
 
 	nextInteractionId int `yaml:"-"`
 
-	// EncodeOptions is an optional list of YAML encoder options.
-	EncodeOptions []yaml.EncodeOption `yaml:"-"`
+	// MarshalFunc is a custom marshal func.
+	MarshalFunc MarshalFunc `yaml:"-"`
 }
 
 // New creates a new empty cassette
@@ -505,12 +508,10 @@ func (c *Cassette) SaveWithFS(fs FS) error {
 	c.Interactions = interactions
 
 	// Marshal to YAML and save interactions
-	var buff bytes.Buffer
-	enc := yaml.NewEncoder(&buff, c.EncodeOptions...)
-	if err := enc.Encode(c); err != nil {
+	data, err := c.MarshalFunc(c)
+	if err != nil {
 		return err
 	}
-	data := buff.Bytes()
 
 	// Honor the YAML structure specification
 	// http://www.yaml.org/spec/1.2/spec.html#id2760395

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -35,7 +35,7 @@ import (
 	"net/http/httputil"
 	"time"
 
-	"github.com/goccy/go-yaml"
+	"go.yaml.in/yaml/v4"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
 )
 
@@ -211,7 +211,7 @@ type Recorder struct {
 	// fs specifies custom filesystem ([cassette.FS]) implementation.
 	fs cassette.FS
 
-	encodeOptions []yaml.EncodeOption
+	marshalFunc cassette.MarshalFunc
 }
 
 // Option is a function which configures the [Recorder].
@@ -316,12 +316,12 @@ func WithFS(fs cassette.FS) Option {
 	return opt
 }
 
-// WithEncodeOptions is an [Option], which configures the [Recorder] to use
-// custom YAML encoder options. This allows customization of the YAML encoding
+// WithMarshalFunc is an [Option], which configures the [Recorder] to use
+// custom YAML marshal func. This allows customization of the YAML encoding
 // process, such as setting string literal style, etc.
-func WithEncodeOptions(encodeOptions ...yaml.EncodeOption) Option {
+func WithMarshalFunc(marshalFunc cassette.MarshalFunc) Option {
 	return func(r *Recorder) {
-		r.encodeOptions = encodeOptions
+		r.marshalFunc = marshalFunc
 	}
 }
 
@@ -338,6 +338,7 @@ func New(cassetteName string, opts ...Option) (*Recorder, error) {
 		matcher:                cassette.DefaultMatcher,
 		replayableInteractions: false,
 		fs:                     cassette.NewDiskFS(),
+		marshalFunc:            yaml.Marshal,
 	}
 
 	for _, opt := range opts {
@@ -352,7 +353,7 @@ func New(cassetteName string, opts ...Option) (*Recorder, error) {
 	r.cassette = c
 	r.cassette.Matcher = r.matcher
 	r.cassette.ReplayableInteractions = r.replayableInteractions
-	r.cassette.EncodeOptions = r.encodeOptions
+	r.cassette.MarshalFunc = r.marshalFunc
 
 	return r, nil
 }


### PR DESCRIPTION
* Closes #131

---

* Migrate to https://github.com/yaml/go-yaml
* Add `WithMarshalFunc` in replace of `WithEncodeOption` from #129

#129 wasn't really released yet (no tag since it was merged), so we probably don't need to worry about this being a breaking change.

Also, `WithMarshalFunc` is a generic func signature `func(in any) (out []byte, err erro)`, so it prevents future breaking changes because we're really exporting any reference to the library.